### PR TITLE
feat: allow admins to toggle user admin role

### DIFF
--- a/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/users/controller/UserController.java
+++ b/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/users/controller/UserController.java
@@ -34,6 +34,7 @@ public class UserController {
     private final DeleteUserUseCase deleteUserUseCase;
     private final UpdateUserUseCase updateUserUseCase;
     private final ToggleStatusUserCase toggleStatusUserUseCase;
+    private final ToggleAdminUserCase toggleAdminUserUseCase;
     private final ChangePasswordUseCase changePasswordUseCase;
 
     @Operation(summary = "Obtener todos los usuarios")
@@ -118,6 +119,20 @@ public class UserController {
     public ResponseEntity<Map<String, String>> toggleStatus(@PathVariable Long id) {
         toggleStatusUserUseCase.execute(id);
         return ResponseEntity.ok(Map.of("message", "El estado ha sido cambiado correctamente"));
+    }
+
+    @Operation(summary = "Asignar o quitar permisos de administrador a un usuario")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Rol actualizado correctamente"),
+            @ApiResponse(responseCode = "404", description = "Usuario no encontrado",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponseDTO.class)))
+    })
+    @PreAuthorize("hasRole('ADMIN')")
+    @PutMapping("/toggle-role/{id}")
+    public ResponseEntity<Map<String, String>> toggleRole(@PathVariable Long id) {
+        toggleAdminUserUseCase.execute(id);
+        return ResponseEntity.ok(Map.of("message", "El rol ha sido actualizado correctamente"));
     }
 
 

--- a/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/users/service/ToggleAdminUserCaseImpl.java
+++ b/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/users/service/ToggleAdminUserCaseImpl.java
@@ -1,0 +1,29 @@
+package com.reservastrenque.reservas_trenque.users.service;
+
+import com.reservastrenque.reservas_trenque.users.domain.Role;
+import com.reservastrenque.reservas_trenque.users.domain.User;
+import com.reservastrenque.reservas_trenque.users.repository.UserRepository;
+import com.reservastrenque.reservas_trenque.users.usecase.ToggleAdminUserCase;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ToggleAdminUserCaseImpl implements ToggleAdminUserCase {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public void execute(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("El usuario que desea actualizar, no fue encontrado en el sistema"));
+        if (user.getRole() == Role.ADMIN) {
+            user.setRole(Role.USER);
+        } else {
+            user.setRole(Role.ADMIN);
+        }
+        userRepository.save(user);
+    }
+}
+

--- a/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/users/usecase/ToggleAdminUserCase.java
+++ b/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/users/usecase/ToggleAdminUserCase.java
@@ -1,0 +1,6 @@
+package com.reservastrenque.reservas_trenque.users.usecase;
+
+public interface ToggleAdminUserCase {
+    void execute(Long id);
+}
+

--- a/FRONTEND/hotel-reservation-app/src/features/users/hooks/useUsers.js
+++ b/FRONTEND/hotel-reservation-app/src/features/users/hooks/useUsers.js
@@ -25,7 +25,20 @@ const useUsers = () => {
     fetchUsers();
   }, []);
 
-  return { users, loading, error, fetchUsers }; // Devolvemos fetchUsers para que pueda usarse en UsersPage
+  const toggleAdmin = async (id) => {
+    setLoading(true);
+    setError(null);
+    try {
+      await apiClient.put(`/users/toggle-role/${id}`);
+      await fetchUsers();
+    } catch (err) {
+      setError(err.response?.data?.message || "Error al actualizar el rol");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { users, loading, error, fetchUsers, toggleAdmin }; // Devolvemos funciones para que pueda usarse en UsersPage
 };
 
 export default useUsers;

--- a/FRONTEND/hotel-reservation-app/src/features/users/pages/UsersList.jsx
+++ b/FRONTEND/hotel-reservation-app/src/features/users/pages/UsersList.jsx
@@ -1,20 +1,14 @@
-import { useMemo, useState, useEffect } from "react";
+import { useMemo, useEffect } from "react";
 import useUsers from "../hooks/useUsers";
 import DataTable from '../../../Components/Tables/DataTable';
 
 const UsersList = () => {
-  const { users, loading, error, fetchUsers } = useUsers();
-
-  const [selectedUser, setSelectedUser] = useState(null);
-  
+  const { users, fetchUsers, toggleAdmin } = useUsers();
 
   useEffect(() => {
-    fetchUsers(); 
-  }, []);
+    fetchUsers();
+  }, [fetchUsers]);
 
-
-
- 
   const columns = useMemo(
     () => [
       { Header: "ID", accessor: "id" },
@@ -29,7 +23,6 @@ const UsersList = () => {
           <div className="d-flex ">
             <button
               className="btn btn-primary btn-sm "
-              // onClick={() => }
               style={{ width: "40px", margin: "0 auto", borderRadius: "150px" }}
             >
               ✏️
@@ -37,19 +30,22 @@ const UsersList = () => {
             <button
               className="btn btn-warning btn-sm"
               style={{ width: "40px", margin: "0 auto", borderRadius: "150px" }}
-              // onClick={() => ()}
             >
-              {row.original.state === "ACTIVO" ? "✅" : "🚫"}
+              {row.original.enabled ? "✅" : "🚫"}
+            </button>
+            <button
+              className="btn btn-secondary btn-sm"
+              style={{ width: "40px", margin: "0 auto", borderRadius: "150px" }}
+              onClick={() => toggleAdmin(row.original.id)}
+            >
+              {row.original.role === "ADMIN" ? "👑" : "➕"}
             </button>
           </div>
         ),
       },
     ],
-    [users]
+    [users, toggleAdmin]
   );
-
-  // if (loading) return <LoadingScreen />;
-  // if (error) return <p>Error: {error}</p>;
 
   return (
     <div className="mt-3 pt-1">
@@ -60,12 +56,6 @@ const UsersList = () => {
         <h2>Usuarios Registrados</h2>
         <DataTable columns={columns} data={users} />
       </div>
-
-   
-
-   
-
-  
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add use case and service to toggle user admin role
- expose endpoint for admin role toggling
- enable UI and hook to promote or demote users

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: numerous prop-types and unused variable errors)*

------
https://chatgpt.com/codex/tasks/task_e_688e95de29e0832c82f45b6b4f12bcb4