### PR TITLE
feat: add admin user registration form

### DIFF
--- a/FRONTEND/hotel-reservation-app/src/features/users/components/UserRegisterForm.jsx
+++ b/FRONTEND/hotel-reservation-app/src/features/users/components/UserRegisterForm.jsx
@@ -1,0 +1,131 @@
+import { useState } from "react";
+import { FaEye, FaEyeSlash } from "react-icons/fa";
+import useForm from "../../../hooks/useForm";
+import { validateAdminUserForm } from "../validation/validateAdminUserForm";
+import { useCreateUser } from "../hooks/useCreateUser";
+
+export default function UserRegisterForm() {
+  const { handleCreateUser, isLoading } = useCreateUser();
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  const { formData, errors, handleChange, handleSubmit, resetForm } = useForm(
+    {
+      firstName: "",
+      lastName: "",
+      email: "",
+      password: "",
+      confirmPassword: "",
+      phone: "",
+    },
+    validateAdminUserForm
+  );
+
+  return (
+    <form
+      onSubmit={handleSubmit((data) => handleCreateUser(data, resetForm))}
+      className="p-4 border rounded card shadow"
+      noValidate
+    >
+      <h3 className="mb-3 text-center">Registrar Usuario</h3>
+
+      <div className="mb-3">
+        <label>Nombre</label>
+        <input
+          type="text"
+          className="form-control"
+          name="firstName"
+          value={formData.firstName}
+          onChange={handleChange}
+        />
+        {errors.firstName && <div className="text-danger">{errors.firstName}</div>}
+      </div>
+
+      <div className="mb-3">
+        <label>Apellido</label>
+        <input
+          type="text"
+          className="form-control"
+          name="lastName"
+          value={formData.lastName}
+          onChange={handleChange}
+        />
+        {errors.lastName && <div className="text-danger">{errors.lastName}</div>}
+      </div>
+
+      <div className="mb-3">
+        <label>Email</label>
+        <input
+          type="email"
+          className="form-control"
+          name="email"
+          value={formData.email}
+          onChange={handleChange}
+        />
+        {errors.email && <div className="text-danger">{errors.email}</div>}
+      </div>
+
+      <div className="mb-3">
+        <label>Contraseña</label>
+        <div className="input-group">
+          <input
+            type={showPassword ? "text" : "password"}
+            className="form-control"
+            name="password"
+            value={formData.password}
+            onChange={handleChange}
+          />
+          <button
+            type="button"
+            className="btn icon-password bg-white"
+            onClick={() => setShowPassword((prev) => !prev)}
+            tabIndex={-1}
+          >
+            {showPassword ? <FaEyeSlash /> : <FaEye />}
+          </button>
+        </div>
+        {errors.password && <div className="text-danger">{errors.password}</div>}
+      </div>
+
+      <div className="mb-3">
+        <label>Confirmar Contraseña</label>
+        <div className="input-group">
+          <input
+            type={showConfirmPassword ? "text" : "password"}
+            className="form-control"
+            name="confirmPassword"
+            value={formData.confirmPassword}
+            onChange={handleChange}
+          />
+          <button
+            type="button"
+            className="btn icon-password bg-white"
+            onClick={() => setShowConfirmPassword((prev) => !prev)}
+            tabIndex={-1}
+          >
+            {showConfirmPassword ? <FaEyeSlash /> : <FaEye />}
+          </button>
+        </div>
+        {errors.confirmPassword && (
+          <div className="text-danger">{errors.confirmPassword}</div>
+        )}
+      </div>
+
+      <div className="mb-3">
+        <label>Teléfono (opcional)</label>
+        <input
+          type="tel"
+          className="form-control"
+          name="phone"
+          value={formData.phone}
+          onChange={handleChange}
+        />
+      </div>
+
+      <button className="btn btn-primary w-100" disabled={isLoading}>
+        {isLoading ? "Registrando..." : "Registrar"}
+      </button>
+    </form>
+  );
+}
+

--- a/FRONTEND/hotel-reservation-app/src/features/users/hooks/useCreateUser.js
+++ b/FRONTEND/hotel-reservation-app/src/features/users/hooks/useCreateUser.js
@@ -1,0 +1,25 @@
+import { useState } from "react";
+import { createUser } from "../services/userService";
+import { showSuccessAlert, showErrorAlert } from "../../../Components/Alerts/alerts";
+
+export const useCreateUser = () => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleCreateUser = async (formData, resetForm) => {
+    try {
+      setIsLoading(true);
+      const { firstName, lastName, email, password, phone } = formData;
+      const payload = { firstName, lastName, email, password, phone };
+      await createUser(payload);
+      showSuccessAlert("Usuario registrado correctamente");
+      resetForm();
+    } catch (error) {
+      showErrorAlert(error.response?.data?.error || "Error al registrar usuario");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { handleCreateUser, isLoading };
+};
+

--- a/FRONTEND/hotel-reservation-app/src/features/users/pages/CreateUserPage.jsx
+++ b/FRONTEND/hotel-reservation-app/src/features/users/pages/CreateUserPage.jsx
@@ -1,0 +1,18 @@
+import AdminNavbar from "../../admin/components/AdminNavbar";
+import BackArrowButton from "../../../Components/BackArrow/BackArrowButton";
+import UserRegisterForm from "../components/UserRegisterForm";
+
+export default function CreateUserPage() {
+  return (
+    <main className="min-h-screen">
+      <AdminNavbar />
+      <div className="container d-flex align-items-center justify-content-center" style={{ minHeight: "80vh" }}>
+        <div className="w-100" style={{ maxWidth: "600px" }}>
+          <UserRegisterForm />
+        </div>
+      </div>
+      <BackArrowButton />
+    </main>
+  );
+}
+

--- a/FRONTEND/hotel-reservation-app/src/features/users/services/userService.js
+++ b/FRONTEND/hotel-reservation-app/src/features/users/services/userService.js
@@ -1,0 +1,7 @@
+import apiClient from "../../../services/apiClient";
+
+export const createUser = async (data) => {
+  const response = await apiClient.post("/users/register", data);
+  return response.data;
+};
+

--- a/FRONTEND/hotel-reservation-app/src/features/users/validation/validateAdminUserForm.js
+++ b/FRONTEND/hotel-reservation-app/src/features/users/validation/validateAdminUserForm.js
@@ -1,0 +1,32 @@
+export const validateAdminUserForm = (values) => {
+  const errors = {};
+
+  if (!values.firstName || !values.firstName.trim()) {
+    errors.firstName = "El nombre es obligatorio";
+  }
+
+  if (!values.lastName || !values.lastName.trim()) {
+    errors.lastName = "El apellido es obligatorio";
+  }
+
+  if (!values.email || !values.email.trim()) {
+    errors.email = "El email es obligatorio";
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(values.email)) {
+    errors.email = "Email inválido";
+  }
+
+  if (!values.password) {
+    errors.password = "La contraseña es obligatoria";
+  } else if (values.password.length < 6) {
+    errors.password = "Mínimo 6 caracteres";
+  }
+
+  if (!values.confirmPassword) {
+    errors.confirmPassword = "Confirmación requerida";
+  } else if (values.password !== values.confirmPassword) {
+    errors.confirmPassword = "Las contraseñas no coinciden";
+  }
+
+  return errors;
+};
+

--- a/FRONTEND/hotel-reservation-app/src/router/AppRouter.jsx
+++ b/FRONTEND/hotel-reservation-app/src/router/AppRouter.jsx
@@ -11,6 +11,7 @@ import { ProtectedRoute } from "./ProtectedRoute";
 import { DeviceProvider } from "../Context/DeviceContext";
 import ProtectedAdminWrapper from "../Components/Modals/ProtectedAdminWrapper";
 import UsersList from "../features/users/pages/UsersList";
+import CreateUserPage from "../features/users/pages/CreateUserPage";
 
 function AppRouter() {
   return (
@@ -34,6 +35,7 @@ function AppRouter() {
           <Route path="/addlodging" element={<AddLodgingPage />} />
           <Route path="/lodgingList" element={<LodgingPageList />} />
           <Route path="/usersList" element={<UsersList />} />
+          <Route path="/admin/users/new" element={<CreateUserPage />} />
           <Route path="/admin/features" element={<FeatureAdminPage />} />
         </Route>
       </Routes>


### PR DESCRIPTION
## Summary
- add admin user registration form
- support creating users via API
- wire new registration page into admin router

## Testing
- `./mvnw -q test` *(failed: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.0)*
- `npm test` *(missing script: "test")*
- `npm run lint` *(errors: react/prop-types, no-unused-vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6893a77d9c4c832c94f4ff99c3f65200