### PR TITLE
feat: add user edit modal

### DIFF
--- a/FRONTEND/hotel-reservation-app/src/features/users/components/UserEditModal.jsx
+++ b/FRONTEND/hotel-reservation-app/src/features/users/components/UserEditModal.jsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from "react";
+import { Modal, Button, Form } from "react-bootstrap";
+import { updateUser } from "../services/userService";
+import { showSuccessAlert, showErrorAlert } from "../../../Components/Alerts/alerts";
+import { validateEditUserForm } from "../validation/validateEditUserForm";
+
+export default function UserEditModal({ show, onClose, user, onUpdated }) {
+  const [formData, setFormData] = useState({
+    id: "",
+    firstName: "",
+    lastName: "",
+    email: "",
+    phone: "",
+    documentNumber: "",
+    address: "",
+    enabled: true,
+    role: "USER",
+    registrationDate: "",
+  });
+  const [errors, setErrors] = useState({});
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (user) {
+      setFormData({
+        id: user.id,
+        firstName: user.firstName || "",
+        lastName: user.lastName || "",
+        email: user.email || "",
+        phone: user.phone || "",
+        documentNumber: user.documentNumber || "",
+        address: user.address || "",
+        enabled: user.enabled,
+        role: user.role,
+        registrationDate: user.registrationDate || "",
+      });
+      setErrors({});
+    }
+  }, [user]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSave = async () => {
+    const validationErrors = validateEditUserForm(formData);
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+    try {
+      setLoading(true);
+      await updateUser(formData);
+      showSuccessAlert("Usuario actualizado", "Los datos se guardaron correctamente");
+      onUpdated?.();
+      onClose();
+    } catch (err) {
+      const message = err?.response?.data?.message || "Error al actualizar el usuario";
+      showErrorAlert("Error", message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Modal show={show} onHide={onClose} centered>
+      <Modal.Header closeButton>
+        <Modal.Title>Editar Usuario</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Form>
+          <Form.Group className="mb-3">
+            <Form.Label>Nombre</Form.Label>
+            <Form.Control
+              type="text"
+              name="firstName"
+              value={formData.firstName}
+              onChange={handleChange}
+            />
+            {errors.firstName && <p className="text-danger mt-2">{errors.firstName}</p>}
+          </Form.Group>
+
+          <Form.Group className="mb-3">
+            <Form.Label>Apellido</Form.Label>
+            <Form.Control
+              type="text"
+              name="lastName"
+              value={formData.lastName}
+              onChange={handleChange}
+            />
+            {errors.lastName && <p className="text-danger mt-2">{errors.lastName}</p>}
+          </Form.Group>
+
+          <Form.Group className="mb-3">
+            <Form.Label>Email</Form.Label>
+            <Form.Control
+              type="email"
+              name="email"
+              value={formData.email}
+              onChange={handleChange}
+            />
+            {errors.email && <p className="text-danger mt-2">{errors.email}</p>}
+          </Form.Group>
+
+          <Form.Group className="mb-3">
+            <Form.Label>Teléfono (opcional)</Form.Label>
+            <Form.Control
+              type="tel"
+              name="phone"
+              value={formData.phone}
+              onChange={handleChange}
+            />
+          </Form.Group>
+        </Form>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={onClose}>
+          Cancelar
+        </Button>
+        <Button variant="primary" onClick={handleSave} disabled={loading}>
+          {loading ? "Guardando..." : "Guardar"}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}
+

--- a/FRONTEND/hotel-reservation-app/src/features/users/pages/UsersList.jsx
+++ b/FRONTEND/hotel-reservation-app/src/features/users/pages/UsersList.jsx
@@ -1,9 +1,22 @@
-import { useMemo, useEffect } from "react";
+import { useMemo, useEffect, useState } from "react";
 import useUsers from "../hooks/useUsers";
 import DataTable from '../../../Components/Tables/DataTable';
+import UserEditModal from "../components/UserEditModal";
 
 const UsersList = () => {
   const { users, fetchUsers, toggleAdmin } = useUsers();
+  const [selectedUser, setSelectedUser] = useState(null);
+  const [showModal, setShowModal] = useState(false);
+
+  const handleOpenEdit = (user) => {
+    setSelectedUser(user);
+    setShowModal(true);
+  };
+
+  const handleCloseModal = () => {
+    setShowModal(false);
+    setSelectedUser(null);
+  };
 
   useEffect(() => {
     fetchUsers();
@@ -24,6 +37,7 @@ const UsersList = () => {
             <button
               className="btn btn-primary btn-sm "
               style={{ width: "40px", margin: "0 auto", borderRadius: "150px" }}
+              onClick={() => handleOpenEdit(row.original)}
             >
               ✏️
             </button>
@@ -56,6 +70,12 @@ const UsersList = () => {
         <h2>Usuarios Registrados</h2>
         <DataTable columns={columns} data={users} />
       </div>
+      <UserEditModal
+        show={showModal}
+        onClose={handleCloseModal}
+        user={selectedUser}
+        onUpdated={fetchUsers}
+      />
     </div>
   );
 };

--- a/FRONTEND/hotel-reservation-app/src/features/users/services/userService.js
+++ b/FRONTEND/hotel-reservation-app/src/features/users/services/userService.js
@@ -5,3 +5,9 @@ export const createUser = async (data) => {
   return response.data;
 };
 
+
+export const updateUser = async (data) => {
+  const response = await apiClient.put("/users", data);
+  return response.data;
+};
+

--- a/FRONTEND/hotel-reservation-app/src/features/users/validation/validateEditUserForm.js
+++ b/FRONTEND/hotel-reservation-app/src/features/users/validation/validateEditUserForm.js
@@ -1,0 +1,20 @@
+export const validateEditUserForm = (values) => {
+  const errors = {};
+
+  if (!values.firstName || !values.firstName.trim()) {
+    errors.firstName = "El nombre es obligatorio";
+  }
+
+  if (!values.lastName || !values.lastName.trim()) {
+    errors.lastName = "El apellido es obligatorio";
+  }
+
+  if (!values.email || !values.email.trim()) {
+    errors.email = "El email es obligatorio";
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(values.email)) {
+    errors.email = "Email inválido";
+  }
+
+  return errors;
+};
+


### PR DESCRIPTION
## Summary
- add service and validation for updating users
- create `UserEditModal` to edit user info
- wire edit modal into UsersList table

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: PropTypes validation errors across project)*

------
https://chatgpt.com/codex/tasks/task_e_6893beeebc18832cb579eb73b05ec119