### PR TITLE
feat: send confirmation email on user registration

### DIFF
--- a/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/users/controller/UserController.java
+++ b/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/users/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.reservastrenque.reservas_trenque.users.controller;
 
 import com.reservastrenque.reservas_trenque.config.exception.ErrorResponseDTO;
+import com.reservastrenque.reservas_trenque.auth.dto.EmailDTO;
 import com.reservastrenque.reservas_trenque.users.dto.ChangePasswordRequest;
 import com.reservastrenque.reservas_trenque.users.dto.CreateUserRequest;
 import com.reservastrenque.reservas_trenque.users.dto.UserDTO;
@@ -36,6 +37,7 @@ public class UserController {
     private final ToggleStatusUserCase toggleStatusUserUseCase;
     private final ToggleAdminUserCase toggleAdminUserUseCase;
     private final ChangePasswordUseCase changePasswordUseCase;
+    private final SendConfirmationEmailUseCase sendConfirmationEmailUseCase;
 
     @Operation(summary = "Obtener todos los usuarios")
     @ApiResponse(responseCode = "200", description = "Lista de usuarios obtenida correctamente")
@@ -72,6 +74,14 @@ public class UserController {
     public ResponseEntity<UserDTO> registerUser(@Valid @RequestBody CreateUserRequest request) {
         UserDTO createdUser = registerUserUseCase.execute(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdUser);
+    }
+
+    @Operation(summary = "Reenviar correo de confirmación de registro")
+    @ApiResponse(responseCode = "200", description = "Correo reenviado correctamente")
+    @PostMapping("/resend-confirmation")
+    public ResponseEntity<Map<String, String>> resendConfirmation(@RequestBody EmailDTO request) {
+        sendConfirmationEmailUseCase.execute(request.getEmail());
+        return ResponseEntity.ok(Map.of("message", "Correo de confirmación reenviado"));
     }
 
     @Operation(summary = "Eliminar un usuario")

--- a/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/users/service/RegisterUserUseCaseImpl.java
+++ b/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/users/service/RegisterUserUseCaseImpl.java
@@ -6,6 +6,7 @@ import com.reservastrenque.reservas_trenque.users.dto.CreateUserRequest;
 import com.reservastrenque.reservas_trenque.users.dto.UserDTO;
 import com.reservastrenque.reservas_trenque.users.repository.UserRepository;
 import com.reservastrenque.reservas_trenque.users.usecase.RegisterUserUseCase;
+import com.reservastrenque.reservas_trenque.users.usecase.SendConfirmationEmailUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -18,6 +19,7 @@ public class RegisterUserUseCaseImpl implements RegisterUserUseCase {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final UserMapper userMapper;
+    private final SendConfirmationEmailUseCase sendConfirmationEmailUseCase;
 
     @Override
     public UserDTO execute(CreateUserRequest request) {
@@ -36,6 +38,9 @@ public class RegisterUserUseCaseImpl implements RegisterUserUseCase {
         newUser.setPassword(passwordEncoder.encode(newUser.getPassword()));
 
         userRepository.save(newUser);
+
+        // Enviar correo de confirmación de registro
+        sendConfirmationEmailUseCase.execute(newUser.getEmail());
 
         return userMapper.toDTO(newUser);
     }

--- a/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/users/service/SendConfirmationEmailUseCaseImpl.java
+++ b/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/users/service/SendConfirmationEmailUseCaseImpl.java
@@ -1,0 +1,39 @@
+package com.reservastrenque.reservas_trenque.users.service;
+
+import com.reservastrenque.reservas_trenque.auth.service.EmailService;
+import com.reservastrenque.reservas_trenque.users.domain.User;
+import com.reservastrenque.reservas_trenque.users.repository.UserRepository;
+import com.reservastrenque.reservas_trenque.users.usecase.SendConfirmationEmailUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SendConfirmationEmailUseCaseImpl implements SendConfirmationEmailUseCase {
+
+    private final UserRepository userRepository;
+    private final EmailService emailService;
+
+    @Value("${app.frontend.login-url}")
+    private String loginUrl;
+
+    @Override
+    public void execute(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("Usuario no encontrado"));
+
+        String subject = "Confirmación de registro";
+        String content = String.format(
+                "Hola %s %s,\n\nTu registro fue exitoso.\n\nNombre de usuario: %s %s\nCorreo electrónico: %s\n\nPuedes iniciar sesión en tu cuenta aquí: %s\n\nSi no solicitaste este registro, ignora este mensaje.",
+                user.getFirstName(),
+                user.getLastName(),
+                user.getFirstName(),
+                user.getLastName(),
+                user.getEmail(),
+                loginUrl
+        );
+
+        emailService.send(user.getEmail(), subject, content);
+    }
+}

--- a/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/users/usecase/SendConfirmationEmailUseCase.java
+++ b/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/users/usecase/SendConfirmationEmailUseCase.java
@@ -1,0 +1,5 @@
+package com.reservastrenque.reservas_trenque.users.usecase;
+
+public interface SendConfirmationEmailUseCase {
+    void execute(String email);
+}

--- a/BACKEND/reservas-trenque/src/main/resources/application.properties
+++ b/BACKEND/reservas-trenque/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.profiles.active=dev
+app.frontend.login-url=http://localhost:5173/login


### PR DESCRIPTION
## Summary
- add use case to send user registration confirmation email
- send confirmation email after registering a user and allow resending
- configure login URL for email template

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.0)*

------
https://chatgpt.com/codex/tasks/task_e_6893c9672f78832c9e9df4b80e03446e