### PR TITLE
feat: add product categories

### DIFF
--- a/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/products/controller/CategoryController.java
+++ b/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/products/controller/CategoryController.java
@@ -1,0 +1,42 @@
+package com.reservastrenque.reservas_trenque.products.controller;
+
+import com.reservastrenque.reservas_trenque.products.dto.CategoryRequest;
+import com.reservastrenque.reservas_trenque.products.dto.CategoryResponse;
+import com.reservastrenque.reservas_trenque.products.service.CategoryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/categories")
+@CrossOrigin(origins = "*")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping
+    public ResponseEntity<List<CategoryResponse>> getAllCategories() {
+        return ResponseEntity.ok(categoryService.getAll());
+    }
+
+    @PostMapping
+    public ResponseEntity<CategoryResponse> createCategory(@Valid @RequestBody CategoryRequest request) {
+        return ResponseEntity.ok(categoryService.create(request));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<CategoryResponse> updateCategory(@PathVariable Long id,
+                                                           @Valid @RequestBody CategoryRequest request) {
+        return ResponseEntity.ok(categoryService.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteCategory(@PathVariable Long id) {
+        categoryService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/products/dto/CategoryRequest.java
+++ b/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/products/dto/CategoryRequest.java
@@ -1,0 +1,19 @@
+package com.reservastrenque.reservas_trenque.products.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CategoryRequest {
+
+    @NotBlank(message = "El título es obligatorio.")
+    private String title;
+
+    private String description;
+
+    private String imageUrl;
+}

--- a/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/products/dto/CategoryResponse.java
+++ b/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/products/dto/CategoryResponse.java
@@ -1,0 +1,15 @@
+package com.reservastrenque.reservas_trenque.products.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CategoryResponse {
+    private Long id;
+    private String title;
+    private String description;
+    private String imageUrl;
+}

--- a/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/products/model/Category.java
+++ b/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/products/model/Category.java
@@ -1,0 +1,27 @@
+package com.reservastrenque.reservas_trenque.products.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "categories")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String title;
+
+    @Column(length = 500)
+    private String description;
+
+    @Column
+    private String imageUrl;
+}

--- a/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/products/persistence/CategoryRepository.java
+++ b/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/products/persistence/CategoryRepository.java
@@ -1,0 +1,9 @@
+package com.reservastrenque.reservas_trenque.products.persistence;
+
+import com.reservastrenque.reservas_trenque.products.model.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/products/service/CategoryService.java
+++ b/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/products/service/CategoryService.java
@@ -1,0 +1,57 @@
+package com.reservastrenque.reservas_trenque.products.service;
+
+import com.reservastrenque.reservas_trenque.products.dto.CategoryRequest;
+import com.reservastrenque.reservas_trenque.products.dto.CategoryResponse;
+import com.reservastrenque.reservas_trenque.products.model.Category;
+import com.reservastrenque.reservas_trenque.products.persistence.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public List<CategoryResponse> getAll() {
+        return categoryRepository.findAll().stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    public CategoryResponse create(CategoryRequest request) {
+        Category category = Category.builder()
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .imageUrl(request.getImageUrl())
+                .build();
+        Category saved = categoryRepository.save(category);
+        return toResponse(saved);
+    }
+
+    public CategoryResponse update(Long id, CategoryRequest request) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Categoría no encontrada"));
+        category.setTitle(request.getTitle());
+        category.setDescription(request.getDescription());
+        category.setImageUrl(request.getImageUrl());
+        Category saved = categoryRepository.save(category);
+        return toResponse(saved);
+    }
+
+    public void delete(Long id) {
+        categoryRepository.deleteById(id);
+    }
+
+    private CategoryResponse toResponse(Category category) {
+        return CategoryResponse.builder()
+                .id(category.getId())
+                .title(category.getTitle())
+                .description(category.getDescription())
+                .imageUrl(category.getImageUrl())
+                .build();
+    }
+}

--- a/FRONTEND/hotel-reservation-app/src/features/admin/components/AdminNavbar.jsx
+++ b/FRONTEND/hotel-reservation-app/src/features/admin/components/AdminNavbar.jsx
@@ -32,6 +32,7 @@ export default function AdminNavbar() {
               <li><NavLink className="dropdown-item" to="/lodgingList">Listar Productos</NavLink></li>
               <li><NavLink className="dropdown-item" to="/addlodging">Agregar Producto</NavLink></li>
               <li><NavLink className="dropdown-item" to="/admin/features">Administrar características</NavLink></li>
+              <li><NavLink className="dropdown-item" to="/admin/categories/new">Agregar categoría</NavLink></li>
             </ul>
           </li>
 

--- a/FRONTEND/hotel-reservation-app/src/features/categories/pages/AddCategoryPage.jsx
+++ b/FRONTEND/hotel-reservation-app/src/features/categories/pages/AddCategoryPage.jsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import AdminNavbar from "../../admin/components/AdminNavbar";
+import { createCategory } from "../services/categoryService";
+
+export default function AddCategoryPage() {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [imageUrl, setImageUrl] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await createCategory({ title, description, imageUrl });
+      setMessage("Categoría creada con éxito");
+      setTitle("");
+      setDescription("");
+      setImageUrl("");
+    } catch (err) {
+      setMessage("Error al crear la categoría");
+    }
+  };
+
+  return (
+    <div>
+      <AdminNavbar />
+      <div className="container mt-4">
+        <h2>Agregar categoría</h2>
+        {message && <p>{message}</p>}
+        <form onSubmit={handleSubmit}>
+          <div className="mb-3">
+            <label className="form-label">Título</label>
+            <input
+              className="form-control"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required
+            />
+          </div>
+          <div className="mb-3">
+            <label className="form-label">Descripción</label>
+            <textarea
+              className="form-control"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+          <div className="mb-3">
+            <label className="form-label">URL de imagen</label>
+            <input
+              className="form-control"
+              value={imageUrl}
+              onChange={(e) => setImageUrl(e.target.value)}
+            />
+          </div>
+          <button type="submit" className="btn btn-primary">
+            Guardar
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/FRONTEND/hotel-reservation-app/src/features/categories/services/categoryService.js
+++ b/FRONTEND/hotel-reservation-app/src/features/categories/services/categoryService.js
@@ -1,0 +1,6 @@
+import apiClient from "../../../services/apiClient";
+
+export const getCategories = () => apiClient.get("/categories");
+export const createCategory = (data) => apiClient.post("/categories", data);
+export const updateCategory = (id, data) => apiClient.put(`/categories/${id}`, data);
+export const deleteCategory = (id) => apiClient.delete(`/categories/${id}`);

--- a/FRONTEND/hotel-reservation-app/src/router/AppRouter.jsx
+++ b/FRONTEND/hotel-reservation-app/src/router/AppRouter.jsx
@@ -8,6 +8,7 @@ import AddLodgingPage from "../features/lodgings/pages/AddLodgingPage";
 import LodgingPageList from "../features/lodgings/pages/LodgingPageList";
 import EditLodgingPage from "../features/lodgings/pages/EditLodgingPage";
 import FeatureAdminPage from "../features/features/pages/FeatureAdminPage";
+import AddCategoryPage from "../features/categories/pages/AddCategoryPage";
 import { ProtectedRoute } from "./ProtectedRoute";
 import { DeviceProvider } from "../Context/DeviceContext";
 import ProtectedAdminWrapper from "../Components/Modals/ProtectedAdminWrapper";
@@ -39,6 +40,7 @@ function AppRouter() {
           <Route path="/usersList" element={<UsersList />} />
           <Route path="/admin/users/new" element={<CreateUserPage />} />
           <Route path="/admin/features" element={<FeatureAdminPage />} />
+          <Route path="/admin/categories/new" element={<AddCategoryPage />} />
         </Route>
       </Routes>
     </DeviceProvider>


### PR DESCRIPTION
## Summary
- add backend category entity and CRUD API
- expose admin UI to create new categories

## Testing
- `mvn -q test` *(fails: Could not resolve parent POM)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 150 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6893ce67d6bc832cbd574e537768b75e