### PR TITLE
refactor: manage lodging types

### DIFF
--- a/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/products/controller/LodgingTypeController.java
+++ b/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/products/controller/LodgingTypeController.java
@@ -35,4 +35,17 @@ public class LodgingTypeController {
         LodgingType created = lodgingTypeUseCase.create(request);
         return ResponseEntity.ok(new ApiResponse<>("Tipo creado", LodgingTypeMapper.toDto(created)));
     }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<LodgingTypeResponse>> update(@PathVariable Long id,
+                                                                   @Valid @RequestBody LodgingTypeRequest request) {
+        LodgingType updated = lodgingTypeUseCase.update(id, request);
+        return ResponseEntity.ok(new ApiResponse<>("Tipo actualizado", LodgingTypeMapper.toDto(updated)));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long id) {
+        lodgingTypeUseCase.delete(id);
+        return ResponseEntity.ok(new ApiResponse<>("Tipo eliminado", null));
+    }
 }

--- a/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/products/service/LodgingTypeService.java
+++ b/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/products/service/LodgingTypeService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -31,5 +32,22 @@ public class LodgingTypeService implements LodgingTypeUseCase {
                 .build();
 
         return repository.save(type);
+    }
+
+    @Override
+    public LodgingType update(Long id, LodgingTypeRequest request) {
+        LodgingType type = repository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Tipo de alojamiento no encontrado"));
+        type.setName(request.getName());
+        type.setIcon(request.getIcon());
+        return repository.save(type);
+    }
+
+    @Override
+    public void delete(Long id) {
+        LodgingType type = repository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Tipo de alojamiento no encontrado"));
+        type.setActive(false);
+        repository.save(type);
     }
 }

--- a/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/products/usecase/LodgingTypeUseCase.java
+++ b/BACKEND/reservas-trenque/src/main/java/com/reservastrenque/reservas_trenque/products/usecase/LodgingTypeUseCase.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface LodgingTypeUseCase {
     List<LodgingType> getAllActive();
     LodgingType create(LodgingTypeRequest request);
+    LodgingType update(Long id, LodgingTypeRequest request);
+    void delete(Long id);
 }

--- a/FRONTEND/hotel-reservation-app/src/features/admin/components/AdminNavbar.jsx
+++ b/FRONTEND/hotel-reservation-app/src/features/admin/components/AdminNavbar.jsx
@@ -32,6 +32,7 @@ export default function AdminNavbar() {
               <li><NavLink className="dropdown-item" to="/lodgingList">Listar Productos</NavLink></li>
               <li><NavLink className="dropdown-item" to="/addlodging">Agregar Producto</NavLink></li>
               <li><NavLink className="dropdown-item" to="/admin/features">Administrar características</NavLink></li>
+              <li><NavLink className="dropdown-item" to="/admin/lodging-types">Tipos de alojamiento</NavLink></li>
             </ul>
           </li>
 

--- a/FRONTEND/hotel-reservation-app/src/features/lodgingTypes/pages/LodgingTypeAdminPage.jsx
+++ b/FRONTEND/hotel-reservation-app/src/features/lodgingTypes/pages/LodgingTypeAdminPage.jsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from "react";
+import AdminNavbar from "../../admin/components/AdminNavbar";
+import {
+  createLodgingType,
+  getLodgingTypes,
+  updateLodgingType,
+  deleteLodgingType,
+} from "../../lodgings/services/lodgingTypeService";
+
+export default function LodgingTypeAdminPage() {
+  const [name, setName] = useState("");
+  const [icon, setIcon] = useState("");
+  const [message, setMessage] = useState("");
+  const [types, setTypes] = useState([]);
+  const [editingId, setEditingId] = useState(null);
+
+  useEffect(() => {
+    fetchTypes();
+  }, []);
+
+  const fetchTypes = async () => {
+    const { data } = await getLodgingTypes();
+    setTypes(data.data);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      if (editingId) {
+        await updateLodgingType(editingId, { name, icon });
+        setMessage("Tipo actualizado");
+      } else {
+        await createLodgingType({ name, icon });
+        setMessage("Tipo creado con éxito");
+      }
+      setName("");
+      setIcon("");
+      setEditingId(null);
+      fetchTypes();
+    } catch {
+      setMessage("Error al guardar el tipo");
+    }
+  };
+
+  const handleEdit = (type) => {
+    setName(type.name);
+    setIcon(type.icon || "");
+    setEditingId(type.id);
+  };
+
+  const handleDelete = async (id) => {
+    await deleteLodgingType(id);
+    fetchTypes();
+  };
+
+  const handleCancel = () => {
+    setName("");
+    setIcon("");
+    setEditingId(null);
+  };
+
+  return (
+    <div>
+      <AdminNavbar />
+      <div className="container mt-4">
+        <div className="row">
+          <div className="col-md-4 mb-4">
+            <div className="card">
+              <div className="card-body">
+                <h2 className="h5 mb-3">
+                  {editingId ? "Editar tipo" : "Agregar tipo"}
+                </h2>
+                {message && <div className="alert alert-info">{message}</div>}
+                <form onSubmit={handleSubmit}>
+                  <div className="mb-3">
+                    <label className="form-label">Nombre</label>
+                    <input
+                      className="form-control"
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                      required
+                    />
+                  </div>
+                  <div className="mb-3">
+                    <label className="form-label">Ícono</label>
+                    <input
+                      className="form-control"
+                      value={icon}
+                      onChange={(e) => setIcon(e.target.value)}
+                    />
+                  </div>
+                  <button type="submit" className="btn btn-primary">
+                    {editingId ? "Actualizar" : "Guardar"}
+                  </button>
+                  {editingId && (
+                    <button
+                      type="button"
+                      className="btn btn-secondary ms-2"
+                      onClick={handleCancel}
+                    >
+                      Cancelar
+                    </button>
+                  )}
+                </form>
+              </div>
+            </div>
+          </div>
+          <div className="col-md-8">
+            <table className="table table-striped">
+              <thead>
+                <tr>
+                  <th>Nombre</th>
+                  <th>Ícono</th>
+                  <th className="text-end">Acciones</th>
+                </tr>
+              </thead>
+              <tbody>
+                {types.length > 0 ? (
+                  types.map((t) => (
+                    <tr key={t.id}>
+                      <td>{t.name}</td>
+                      <td>{t.icon}</td>
+                      <td className="text-end">
+                        <button
+                          className="btn btn-sm btn-outline-primary me-2"
+                          onClick={() => handleEdit(t)}
+                        >
+                          Editar
+                        </button>
+                        <button
+                          className="btn btn-sm btn-outline-danger"
+                          onClick={() => handleDelete(t.id)}
+                        >
+                          Eliminar
+                        </button>
+                      </td>
+                    </tr>
+                  ))
+                ) : (
+                  <tr>
+                    <td colSpan="3" className="text-center">
+                      No hay tipos
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/FRONTEND/hotel-reservation-app/src/features/lodgings/services/lodgingTypeService.js
+++ b/FRONTEND/hotel-reservation-app/src/features/lodgings/services/lodgingTypeService.js
@@ -8,3 +8,11 @@ export const getLodgingTypes = () => {
 export const createLodgingType = (data) => {
   return apiClient.post("/lodging-types", data);
 };
+
+export const updateLodgingType = (id, data) => {
+  return apiClient.put(`/lodging-types/${id}`, data);
+};
+
+export const deleteLodgingType = (id) => {
+  return apiClient.delete(`/lodging-types/${id}`);
+};

--- a/FRONTEND/hotel-reservation-app/src/router/AppRouter.jsx
+++ b/FRONTEND/hotel-reservation-app/src/router/AppRouter.jsx
@@ -8,6 +8,7 @@ import AddLodgingPage from "../features/lodgings/pages/AddLodgingPage";
 import LodgingPageList from "../features/lodgings/pages/LodgingPageList";
 import EditLodgingPage from "../features/lodgings/pages/EditLodgingPage";
 import FeatureAdminPage from "../features/features/pages/FeatureAdminPage";
+import LodgingTypeAdminPage from "../features/lodgingTypes/pages/LodgingTypeAdminPage";
 import { ProtectedRoute } from "./ProtectedRoute";
 import { DeviceProvider } from "../Context/DeviceContext";
 import ProtectedAdminWrapper from "../Components/Modals/ProtectedAdminWrapper";
@@ -39,6 +40,7 @@ function AppRouter() {
           <Route path="/usersList" element={<UsersList />} />
           <Route path="/admin/users/new" element={<CreateUserPage />} />
           <Route path="/admin/features" element={<FeatureAdminPage />} />
+          <Route path="/admin/lodging-types" element={<LodgingTypeAdminPage />} />
         </Route>
       </Routes>
     </DeviceProvider>


### PR DESCRIPTION
## Summary
- remove obsolete category implementation
- add update and soft-delete operations for lodging types
- provide admin page to create, edit, and remove lodging types

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network unreachable)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 149 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6893ce67d6bc832cbd574e537768b75e