### PR TITLE
feat: add category filter for lodgings

### DIFF
--- a/FRONTEND/hotel-reservation-app/src/features/categories/components/CategoryFilter.jsx
+++ b/FRONTEND/hotel-reservation-app/src/features/categories/components/CategoryFilter.jsx
@@ -1,0 +1,31 @@
+function CategoryFilter({ categories, selectedCategories, onToggle, onClear }) {
+  return (
+    <div className="categories-list">
+      {categories.map((cat) => (
+        <label
+          key={cat.id}
+          className="category-item d-flex align-items-center"
+        >
+          <input
+            type="checkbox"
+            className="form-check-input me-2"
+            checked={selectedCategories.includes(cat.name)}
+            onChange={() => onToggle(cat.name)}
+          />
+          {cat.name}
+        </label>
+      ))}
+      {selectedCategories.length > 0 && (
+        <button
+          type="button"
+          className="btn btn-link mt-2 p-0"
+          onClick={onClear}
+        >
+          Limpiar filtros
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default CategoryFilter;

--- a/FRONTEND/hotel-reservation-app/src/pages/Home/Home.css
+++ b/FRONTEND/hotel-reservation-app/src/pages/Home/Home.css
@@ -41,18 +41,19 @@
 .recommendation-item {
   background-color: #27496d !important; /* Azul profesional */
   color: #ffffff; /* Texto blanco */
-  padding: 15px 20px;
+  padding: 10px 15px;
   border-radius: 8px; /* Bordes redondeados */
-  text-align: center;
   cursor: pointer;
   transition: all 0.3s ease;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); /* Sombra suave */
+  display: flex;
+  align-items: center;
 }
 
 /* Efecto hover */
 .category-item:hover,
 .recommendation-item:hover {
-  background-color: #092060 ; /* Azul más oscuro */
+  background-color: #092060; /* Azul más oscuro */
   box-shadow: 0 6px 10px rgba(0, 0, 0, 0.2); /* Más profundidad */
 }
 
@@ -60,6 +61,10 @@
 .category-item,
 .recommendation-item {
   border: 1px solid rgba(255, 255, 255, 0.2); /* Borde sutil */
+}
+
+.category-item input[type="checkbox"] {
+  margin-right: 8px;
 }
 
 /* Recomendaciones */


### PR DESCRIPTION
## Summary
- add reusable `CategoryFilter` component
- enable filtering lodgings by selected categories with counts and pagination update
- style category items and checkbox support

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 145 errors, 10 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68964e9a88f8832c9efda96302eb3c09